### PR TITLE
fix: endpoints que requerem autenticação

### DIFF
--- a/src/main/java/br/com/fiap/trabalho/config/WebSecurityConfig.java
+++ b/src/main/java/br/com/fiap/trabalho/config/WebSecurityConfig.java
@@ -48,9 +48,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .antMatchers("/auth/**").permitAll()
-                .antMatchers("/swagger-ui.html").permitAll()
-                .anyRequest().authenticated()
+                .antMatchers("/cadastro/**").authenticated()
+                .antMatchers("/transacoes/**").authenticated()
+                .antMatchers("/actuator/**").authenticated()
+                .anyRequest().permitAll()
                 .and()
                 .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .and()


### PR DESCRIPTION
Requer autenticação para os endpoints da API e actuator, liberando os demais, para que o swagger funcione. 